### PR TITLE
Fix: Barrels and Crates now drop their respective item

### DIFF
--- a/src/main/java/com/kikis/ptdyeplus/init/BlockInit.java
+++ b/src/main/java/com/kikis/ptdyeplus/init/BlockInit.java
@@ -23,13 +23,13 @@ public class BlockInit{
 
     public static final RegistryObject<Barrel> BARREL = register(
             "barrel_barrel",
-            () -> new Barrel(BlockBehaviour.Properties.of(Material.METAL).sound(SoundType.METAL).dynamicShape()),
+            () -> new Barrel(BlockBehaviour.Properties.of(Material.METAL).sound(SoundType.METAL).dynamicShape().strength(2, 8)),
             new Item.Properties().tab(CreativeModeTab.TAB_DECORATIONS)
     );
 
     public static final RegistryObject<Crate> CRATE = register(
             "crate_barrel",
-            () -> new Crate(BlockBehaviour.Properties.of(Material.METAL).sound(SoundType.METAL).dynamicShape()),
+            () -> new Crate(BlockBehaviour.Properties.of(Material.METAL).sound(SoundType.METAL).dynamicShape().strength(2, 8)),
             new Item.Properties().tab(CreativeModeTab.TAB_DECORATIONS)
     );
 

--- a/src/main/resources/data/ptdyeplus/loot_tables/blocks/barrel_barrel.json
+++ b/src/main/resources/data/ptdyeplus/loot_tables/blocks/barrel_barrel.json
@@ -1,0 +1,26 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "bonus_rolls": 0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ptdyeplus:barrel_barrel",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ]
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/ptdyeplus/loot_tables/blocks/crate_barrel.json
+++ b/src/main/resources/data/ptdyeplus/loot_tables/blocks/crate_barrel.json
@@ -1,0 +1,26 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "bonus_rolls": 0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ptdyeplus:crate_barrel",
+          "functions": [
+            {
+              "function": "minecraft:copy_name",
+              "source": "block_entity"
+            }
+          ]
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Previous I had forgotten to add their loot table - so when broken they would only drop the items inside the container and not the block that was broken. I also added hardness values to their block properties so they wouldn't break in a short amount of time spilling items everywhere. 
[ptdyeplus-1.5.1+forge-1.19.2.jar.zip](https://github.com/game-design-driven/ptdye-plus/files/14065345/ptdyeplus-1.5.1%2Bforge-1.19.2.jar.zip)
